### PR TITLE
Moved ExcludeQuery to another package.

### DIFF
--- a/collector/src/main/java/su/nlq/prometheus/jmx/ExcludeQuery.java
+++ b/collector/src/main/java/su/nlq/prometheus/jmx/ExcludeQuery.java
@@ -1,8 +1,9 @@
-package javax.management;
+package su.nlq.prometheus.jmx;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.management.*;
 import java.util.Collection;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;


### PR DESCRIPTION
to fix
java.lang.NoClassDefFoundError: javax/management/ExcludeQuery
	at su.nlq.prometheus.jmx.MBeansCollector.<init>(MBeansCollector.java:25)
	at su.nlq.prometheus.jmx.MBeansCollector$ExtrusiveCollector.<init>(MBeansCollector.java:63)
	at su.nlq.prometheus.jmx.MBeansCollector.create(MBeansCollector.java:19)
	at su.nlq.prometheus.jmx.JmxCollector.register(JmxCollector.java:23)
on JDK11